### PR TITLE
ci(cloudrun): fix secret scan; correct streaming Dockerfile; setup-gcloud v2; align Artifact Registry; add DB docs; streaming proxy uses PORT

### DIFF
--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -62,12 +62,20 @@ jobs:
         fi
         echo "Configuration validation passed"
         
-    - name: Check for secrets
+    - name: Check for secrets in env files
+      shell: bash
       run: |
-        echo "Checking for accidentally committed secrets..."
-        if grep -r "AUTH0_CLIENT_SECRET=" . --exclude-dir=.git --exclude="*.template" --exclude="*.md"; then
-          echo "Error: Found potential secrets in code"
-          exit 1
+        echo "Scanning .env files for committed secrets..."
+        # List tracked env-like files only
+        mapfile -t files < <(git ls-files | grep -E '(^|/)\.env(\..*)?$|(^|/).*\.env$' || true)
+        if [ ${#files[@]} -gt 0 ]; then
+          # Find any AUTH0_CLIENT_SECRET with a value other than the known placeholder
+          matches=$(grep -n -E '^AUTH0_CLIENT_SECRET=' "${files[@]}" 2>/dev/null | grep -v 'your_client_secret_here' || true)
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            echo "Error: Found potential AUTH0_CLIENT_SECRET value in committed .env files"
+            exit 1
+          fi
         fi
         echo "Secret check passed"
 
@@ -87,7 +95,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v1
+      uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ env.PROJECT_ID }}
         service_account_key: ${{ secrets.GOOGLE_CLOUD_CREDENTIALS }}

--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -163,7 +163,19 @@ jobs:
           
     - name: Deploy API Service
       if: github.event.inputs.service == 'all' || github.event.inputs.service == '' || github.event.inputs.service == 'api'
+      env:
+        CLOUDSQL_INSTANCE_CONNECTION: ${{ secrets.CLOUDSQL_INSTANCE_CONNECTION }}
+        VPC_CONNECTOR: ${{ secrets.VPC_CONNECTOR }}
       run: |
+        if [ -n "${CLOUDSQL_INSTANCE_CONNECTION}" ] && [ -n "${VPC_CONNECTOR}" ]; then
+          DB_FLAGS="--add-cloudsql-instances=${CLOUDSQL_INSTANCE_CONNECTION} --vpc-connector=${VPC_CONNECTOR}"
+          DB_ENV="DB_TYPE=postgres,DB_HOST=/cloudsql/${CLOUDSQL_INSTANCE_CONNECTION},DB_PORT=5432,DB_NAME=cloudtolocalllm,DB_USER=cloudtolocalllm,DB_SSL=true"
+          DB_SECRETS="--set-secrets=DB_PASSWORD=db-password:latest"
+        else
+          DB_FLAGS=""
+          DB_ENV="DB_TYPE=sqlite"
+          DB_SECRETS=""
+        fi
         gcloud run deploy cloudtolocalllm-api \
           --image=${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/api:${{ github.sha }} \
           --platform=managed \
@@ -177,7 +189,8 @@ jobs:
           --concurrency=100 \
           --timeout=900 \
           --service-account=cloudtolocalllm-runner@${{ env.PROJECT_ID }}.iam.gserviceaccount.com \
-          --set-env-vars="NODE_ENV=production,LOG_LEVEL=info,DB_TYPE=sqlite,FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID || 'cloudtolocalllm-auth' }}" \
+          --set-env-vars="NODE_ENV=production,LOG_LEVEL=info,${DB_ENV},FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID || 'cloudtolocalllm-auth' }}" \
+          ${DB_FLAGS} ${DB_SECRETS} \
           --quiet
           
     - name: Deploy Streaming Service

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,23 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: cloudtolocalllm-db
+    environment:
+      POSTGRES_DB: cloudtolocalllm
+      POSTGRES_USER: cloudtolocalllm
+      POSTGRES_PASSWORD: changeme
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cloudtolocalllm"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db_data:
+

--- a/docs/DEPLOYMENT/CLOUD_SQL_SETUP.md
+++ b/docs/DEPLOYMENT/CLOUD_SQL_SETUP.md
@@ -1,0 +1,76 @@
+# Cloud SQL Setup for CloudToLocalLLM
+
+This guide walks through configuring Google Cloud SQL (Postgres) with Cloud Run.
+
+## Enable APIs
+```
+gcloud services enable sqladmin.googleapis.com vpcaccess.googleapis.com
+```
+
+## Create Cloud SQL Instance
+```
+INSTANCE_ID=cloudtolocalllm-pg
+REGION=us-east4
+DB_VERSION=POSTGRES_16
+
+gcloud sql instances create $INSTANCE_ID \
+  --database-version=$DB_VERSION \
+  --tier=db-custom-1-3840 \
+  --region=$REGION \
+  --storage-auto-increase \
+  --availability-type=ZONAL \
+  --backup
+```
+
+## Create Database and User
+```
+gcloud sql databases create cloudtolocalllm --instance=$INSTANCE_ID
+
+DB_PASSWORD=$(openssl rand -base64 24)
+echo -n "$DB_PASSWORD" | gcloud secrets create db-password --data-file=- --replication-policy=automatic
+
+gcloud sql users create cloudtolocalllm --instance=$INSTANCE_ID --password=$DB_PASSWORD
+```
+
+## Create Serverless VPC Access Connector
+```
+CONNECTOR=cloudtolocalllm-connector
+SUBNET=default  # replace with a dedicated subnet in production
+
+gcloud compute networks vpc-access connectors create $CONNECTOR \
+  --region=$REGION \
+  --network=default \
+  --range=10.8.0.0/28
+```
+
+## Configure Cloud Run (API)
+```
+PROJECT_ID=$(gcloud config get-value project)
+INSTANCE_CONN=$(gcloud sql instances describe $INSTANCE_ID --format='value(connectionName)')
+
+# Deploy (example)
+gcloud run deploy cloudtolocalllm-api \
+  --image=$REGION-docker.pkg.dev/$PROJECT_ID/cloudtolocalllm/api:latest \
+  --platform=managed \
+  --region=$REGION \
+  --allow-unauthenticated \
+  --port=8080 \
+  --memory=2Gi \
+  --cpu=2 \
+  --min-instances=0 \
+  --max-instances=20 \
+  --concurrency=100 \
+  --timeout=900 \
+  --service-account=cloudtolocalllm-runner@$PROJECT_ID.iam.gserviceaccount.com \
+  --add-cloudsql-instances=$INSTANCE_CONN \
+  --vpc-connector=$CONNECTOR \
+  --set-env-vars="NODE_ENV=production,LOG_LEVEL=info,DB_TYPE=postgres,DB_HOST=/cloudsql/$INSTANCE_CONN,DB_PORT=5432,DB_NAME=cloudtolocalllm,DB_USER=cloudtolocalllm,DB_SSL=true" \
+  --set-secrets="DB_PASSWORD=db-password:latest" \
+  --quiet
+```
+
+## Notes
+- For private IP only, adjust DB_HOST accordingly and ensure routing via VPC connector.
+- Ensure `cloudtolocalllm-runner@` has `roles/cloudsql.client`.
+- Rotate the `db-password` secret regularly.
+

--- a/docs/DEPLOYMENT/DATABASE_OPTIONS.md
+++ b/docs/DEPLOYMENT/DATABASE_OPTIONS.md
@@ -1,7 +1,7 @@
 # Database Options for CloudToLocalLLM
 
 This document explains how to use a SQL database in two scenarios:
-- Cloud Run with Google Cloud SQL (managed Postgres)
+- Cloud Run with Google Cloud SQL (managed Postgres, private IP only)
 - Self-hosted/local with Docker Compose Postgres
 
 ## 1) Cloud Run with Cloud SQL (Postgres)
@@ -77,10 +77,11 @@ This document explains how to use a SQL database in two scenarios:
 
 ### Cloud Run Deployment Flags (API Service)
 - Add to `gcloud run deploy cloudtolocalllm-api`:
-  - `--add-cloudsql-instances=$INSTANCE_CONNECTION` (if using Cloud SQL)
-  - `--vpc-connector=$VPC_CONNECTOR` (if using private networking)
+  - `--add-cloudsql-instances=$INSTANCE_CONNECTION`
+  - `--vpc-connector=$VPC_CONNECTOR` (same region as Cloud Run)
   - `--set-env-vars="DB_TYPE=postgres,DB_HOST=/cloudsql/$INSTANCE_CONNECTION,DB_PORT=5432,DB_NAME=cloudtolocalllm,DB_USER=cloudtolocalllm,DB_SSL=true"`
   - `--set-secrets="DB_PASSWORD=db-password:latest"`
+- Ensure Cloud SQL instance is created with `--no-assign-ip` and a VPC connector is configured.
 
 ### Local Development
 - Use docker-compose.db.yml and set env as above.

--- a/docs/DEPLOYMENT/DATABASE_OPTIONS.md
+++ b/docs/DEPLOYMENT/DATABASE_OPTIONS.md
@@ -1,0 +1,100 @@
+# Database Options for CloudToLocalLLM
+
+This document explains how to use a SQL database in two scenarios:
+- Cloud Run with Google Cloud SQL (managed Postgres)
+- Self-hosted/local with Docker Compose Postgres
+
+## 1) Cloud Run with Cloud SQL (Postgres)
+
+### Architecture
+- Cloud Run services (api, web, streaming)
+- Cloud SQL Postgres instance
+- Private connection via Serverless VPC Access (recommended) or public with IAM DB Auth (not covered here)
+
+### Prerequisites
+- Google Cloud project with billing
+- Roles (for CI deployer and runtime SA):
+  - CI/deployer: roles/run.admin, roles/artifactregistry.writer, roles/iam.serviceAccountUser, roles/cloudsql.admin (for provisioning), roles/compute.networkAdmin (for VPC connector)
+  - Runtime SA (cloudtolocalllm-runner@...): roles/run.invoker, roles/cloudsql.client, roles/logging.logWriter, roles/monitoring.metricWriter
+
+### Provisioning Steps (high level)
+1. Enable APIs: sqladmin.googleapis.com, vpcaccess.googleapis.com
+2. Create Cloud SQL Postgres instance (db-custom-1-3840 or similar)
+3. Create a database and user: cloudtolocalllm / cloudtolocalllm
+4. Create a Serverless VPC Access connector
+5. Configure Cloud Run services with:
+   - --add-cloudsql-instances=<INSTANCE_CONNECTION_NAME>
+   - --vpc-connector=<CONNECTOR_NAME>
+   - --set-env-vars="DB_TYPE=postgres,DB_HOST=/cloudsql/<INSTANCE_CONNECTION_NAME>,DB_NAME=cloudtolocalllm,DB_USER=cloudtolocalllm,DB_SSL=true"
+   - --set-secrets="DB_PASSWORD=db-password:latest"
+
+### Application Configuration
+- API backend should detect DB_TYPE=postgres and use pg Pool instead of SQLite.
+- Migrations should run against Postgres (e.g., via node-postgres).
+
+### CI/CD Integration
+- Add secret DB_PASSWORD (Secret Manager) and bind it in deploy step.
+- Add GOOGLE_CLOUD_CREDENTIALS, GCP_PROJECT_ID, GCP_REGION to GitHub Secrets.
+- Update deployment scripts to pass Cloud SQL flags/env to `gcloud run deploy`.
+
+## 2) Self-hosted/Local (Docker Compose Postgres)
+
+### Quick Start
+- `docker compose -f docker-compose.db.yml up -d`
+- Postgres runs on localhost:5432 with db/user cloudtolocalllm, password changeme.
+- Set env for API backend:
+  - DB_TYPE=postgres
+  - DB_HOST=localhost
+  - DB_PORT=5432
+  - DB_NAME=cloudtolocalllm
+  - DB_USER=cloudtolocalllm
+  - DB_PASSWORD=changeme
+  - DB_SSL=false
+
+### Development Workflow
+- Start DB via compose
+- Run API with Postgres env
+- Execute migrations (see below)
+
+## Migration Strategy
+
+### Current State
+- migrations/database/migrate.js implements SQLite migrations and references a `pool` for Postgres that is not yet wired.
+
+### Plan
+1. Introduce a DB abstraction in the API backend (e.g., DatabaseClient) that supports drivers: sqlite, postgres.
+2. For Postgres:
+   - Use `pg` and Pool
+   - Implement table creation/migrations: reuse migration SQL with parameterization where needed
+   - Store migrations in a `schema_migrations` table (same shape as SQLite)
+3. Bootstrapping:
+   - Detect DB_TYPE and initialize driver accordingly
+   - If Postgres: connect via host/port or Cloud SQL Unix socket at /cloudsql/<INSTANCE>
+4. CLI:
+   - `node services/api-backend/database/migrate.js init|validate|status|stats` should operate on the active DB driver
+
+## Deployment Changes
+
+### Cloud Run Deployment Flags (API Service)
+- Add to `gcloud run deploy cloudtolocalllm-api`:
+  - `--add-cloudsql-instances=$INSTANCE_CONNECTION` (if using Cloud SQL)
+  - `--vpc-connector=$VPC_CONNECTOR` (if using private networking)
+  - `--set-env-vars="DB_TYPE=postgres,DB_HOST=/cloudsql/$INSTANCE_CONNECTION,DB_PORT=5432,DB_NAME=cloudtolocalllm,DB_USER=cloudtolocalllm,DB_SSL=true"`
+  - `--set-secrets="DB_PASSWORD=db-password:latest"`
+
+### Local Development
+- Use docker-compose.db.yml and set env as above.
+
+## Security Considerations
+- Store DB_PASSWORD in Secret Manager for Cloud Run; avoid committing credentials.
+- Limit DB user permissions to least privilege.
+- For Cloud SQL: prefer private IP and VPC connector; if public, restrict via authorized networks.
+
+## Next Steps Checklist
+- [ ] Add Postgres driver and pool usage in API backend
+- [ ] Implement DB adapter with SQLite and Postgres
+- [ ] Parameterize migrations for Postgres
+- [ ] Update cloudrun-deploy workflow to optionally pass Cloud SQL flags
+- [ ] Extend config/cloudrun/setup-environment.sh to create db-password secret
+- [ ] Validate on staging
+

--- a/services/api-backend/database/db-adapter.js
+++ b/services/api-backend/database/db-adapter.js
@@ -1,0 +1,78 @@
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import pg from 'pg';
+import { TunnelLogger } from '../utils/logger.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const { Pool } = pg;
+
+export class DBAdapter {
+  constructor(env = process.env) {
+    this.env = env;
+    this.type = (env.DB_TYPE || 'sqlite').toLowerCase();
+    this.logger = new TunnelLogger('db-adapter');
+    this.sqlite = null;
+    this.pgPool = null;
+  }
+
+  async connect() {
+    if (this.type === 'postgres') {
+      return this.#connectPostgres();
+    }
+    return this.#connectSqlite();
+  }
+
+  async #connectSqlite() {
+    const filename = this.env.DB_PATH || join(__dirname, '../data/cloudtolocalllm.db');
+    this.sqlite = await open({ filename, driver: sqlite3.Database });
+    await this.sqlite.get('SELECT 1');
+    this.logger.info('Connected to SQLite', { filename });
+    return { driver: 'sqlite', client: this.sqlite };
+  }
+
+  async #connectPostgres() {
+    const cfg = this.#pgConfigFromEnv();
+    this.pgPool = new Pool(cfg);
+    await this.pgPool.query('SELECT 1');
+    this.logger.info('Connected to Postgres', { host: cfg.host || cfg.hostaddr || cfg.connectionString || cfg.host_unix_socket || 'socket' });
+    return { driver: 'postgres', client: this.pgPool };
+  }
+
+  #pgConfigFromEnv() {
+    const {
+      DB_HOST,
+      DB_PORT = '5432',
+      DB_NAME,
+      DB_USER,
+      DB_PASSWORD,
+      DB_SSL,
+    } = this.env;
+
+    // Support Cloud SQL Unix socket path via host like /cloudsql/PROJECT:REGION:INSTANCE
+    const isUnixSocket = DB_HOST && DB_HOST.startsWith('/cloudsql/');
+
+    const base = {
+      database: DB_NAME,
+      user: DB_USER,
+      password: DB_PASSWORD,
+      port: parseInt(DB_PORT, 10),
+      ssl: DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+    };
+
+    if (isUnixSocket) {
+      return {
+        ...base,
+        host: undefined,
+        // pg supports unix domain socket by providing host as the directory containing .s.PGSQL.5432
+        // Cloud SQL sidecar mounts /cloudsql/INSTANCE/.s.PGSQL.5432
+        // Use host as the directory path and it will use a domain socket
+        host: DB_HOST,
+      };
+    }
+
+    return { ...base, host: DB_HOST };
+  }
+}
+

--- a/services/api-backend/package-lock.json
+++ b/services/api-backend/package-lock.json
@@ -19,6 +19,7 @@
         "jsonwebtoken": "^9.0.2",
         "jwks-client": "^2.0.0",
         "node-fetch": "^3.3.2",
+        "pg": "^8.16.3",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.6",
         "uuid": "^9.0.1",
@@ -7103,6 +7104,95 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7200,6 +7290,45 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -8022,6 +8151,15 @@
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
       "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -8918,6 +9056,15 @@
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/services/api-backend/package.json
+++ b/services/api-backend/package.json
@@ -35,14 +35,15 @@
     "jsonwebtoken": "^9.0.2",
     "jwks-client": "^2.0.0",
     "node-fetch": "^3.3.2",
+    "pg": "^8.16.3",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.6",
     "uuid": "^9.0.1",
     "winston": "^3.11.0"
   },
   "devDependencies": {
-    "eslint": "^9.15.0",
     "@eslint/js": "^9.15.0",
+    "eslint": "^9.15.0",
     "globals": "^15.12.0",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
@@ -74,7 +75,13 @@
     ],
     "reporters": [
       "default",
-      ["jest-junit", { "outputDirectory": "<rootDir>/services/api-backend/test-results", "outputName": "junit.xml" }]
+      [
+        "jest-junit",
+        {
+          "outputDirectory": "<rootDir>/services/api-backend/test-results",
+          "outputName": "junit.xml"
+        }
+      ]
     ]
   }
 }

--- a/services/streaming-proxy/proxy-server.js
+++ b/services/streaming-proxy/proxy-server.js
@@ -3,7 +3,7 @@ import https from 'https';
 import winston from 'winston';
 
 // Configuration from environment variables
-const PORT = process.env.HEALTH_PORT || 8080;
+const PORT = process.env.PORT || process.env.HEALTH_PORT || 8080;
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
 const USER_ID = process.env.USER_ID; // Injected by container orchestrator
 const PROXY_ID = process.env.PROXY_ID; // Unique proxy identifier


### PR DESCRIPTION
This PR fixes the Cloud Run workflow, implements private-only Cloud SQL readiness, and improves deployment reliability.

Key changes:
- Secret scan: limit to tracked .env files; ignore known placeholders
- Validate and build streaming service with the dedicated Dockerfile
- Bump google-github-actions/setup-gcloud to v2
- Align Artifact Registry repository name to `cloudtolocalllm`
- Add `.env.mcp.template` for safe local config patterns
- Streaming proxy now honors PORT env (Cloud Run best practice)
- Database updates:
  - Introduce Postgres-capable DB adapter (sqlite + postgres)
  - Refactor migrate.js to dual-driver (sqlite/postgres) with adapter wiring
  - Add pg dependency
  - Private-only Cloud SQL integration readiness:
    - scripts/cloudrun/deploy-to-cloudrun.sh supports --add-cloudsql-instances and --vpc-connector when DB_TYPE=postgres
    - Workflow deploy step conditionally sets private DB flags, envs, and DB_PASSWORD Secret Manager binding
  - Add docs: DATABASE_OPTIONS.md and CLOUD_SQL_SETUP.md
  - Add docker-compose.db.yml for local Postgres

Next steps:
- Add GitHub secrets: GOOGLE_CLOUD_CREDENTIALS, GCP_PROJECT_ID (optional), GCP_REGION (optional), FIREBASE_PROJECT_ID
- Add CLOUDSQL_INSTANCE_CONNECTION and VPC_CONNECTOR secrets for private connectivity
- Configure Cloud SQL instance with --no-assign-ip and create Serverless VPC connector
- Trigger workflow_dispatch for staging to validate builds and deploys

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author