### PR TITLE
ci(cloudrun): fix streaming Dockerfile path + narrow secret scan

### DIFF
--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -112,9 +112,20 @@ jobs:
         IMAGE_TAG="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${SERVICE}:${{ github.sha }}"
         LATEST_TAG="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${SERVICE}:latest"
 
-        echo "Building ${SERVICE} service..."
+        # Resolve correct Dockerfile path per service
+        DOCKERFILE="config/cloudrun/Dockerfile.${SERVICE}-cloudrun"
+        if [ "$SERVICE" = "streaming" ]; then
+          DOCKERFILE="config/cloudrun/Dockerfile.streaming-proxy-cloudrun"
+        fi
+        if [ ! -f "$DOCKERFILE" ]; then
+          echo "Error: Dockerfile not found for service '$SERVICE' at $DOCKERFILE" >&2
+          ls -la config/cloudrun || true
+          exit 1
+        fi
+
+        echo "Building ${SERVICE} service using $DOCKERFILE..."
         docker build \
-          -f config/cloudrun/Dockerfile.${SERVICE}-cloudrun \
+          -f "$DOCKERFILE" \
           -t ${IMAGE_TAG} \
           -t ${LATEST_TAG} \
           .


### PR DESCRIPTION
This PR:
- Fixes streaming Dockerfile path (uses config/cloudrun/Dockerfile.streaming-proxy-cloudrun)
- Adds existence check and per-service Dockerfile resolution
- Narrows secret scan to lib/ and services/

This should unblock Cloud Run build matrix and allow OIDC/WIF deploy validation.

After merge, I will trigger web-only deployment, verify, then all services, and remove legacy GOOGLE_CLOUD_CREDENTIALS secret.