### PR TITLE
GCIP Cloud Run runtime injection and workflow fallback

### DIFF
--- a/.augment/rules/Architecture.md
+++ b/.augment/rules/Architecture.md
@@ -1,0 +1,94 @@
+---
+type: "agent_requested"
+description: "CloudToLocalLLM Architecture Rules and Reference"
+---
+
+## Purpose
+Authoritative reference for the CloudToLocalLLM system architecture. These rules guide design, integration, configuration, and deployment across components so the system remains secure, observable, and operable.
+
+## System Overview
+- Frontend: Flutter Web app served via Nginx on Cloud Run
+- Backend API: Node.js/Express on Cloud Run (primary data/API plane)
+- Streaming Proxy: Cloud Run service optimized for streaming responses
+- Authentication: Google Cloud Identity Platform (GCIP) using Google Identity Services (GIS) on the web; no deprecated google_sign_in plugin for web
+- Data Store: Cloud SQL for PostgreSQL in production; SQLite permitted only for local development
+- CI/CD: GitHub Actions with Workload Identity Federation (WIF) to GCP
+- Secrets: GitHub Actions Secrets and GCP Secret Manager (for runtime values like DB passwords)
+
+## Services and Names
+- Web: cloudtolocalllm-web
+- API: cloudtolocalllm-api
+- Streaming: cloudtolocalllm-streaming
+- Project: cloudtolocalllm-468303
+- Regions: Prefer us-central1 for runtime services; keep build/push region variables consistent across the workflow. Avoid multi-region drift.
+
+## Authentication and Identity
+- GCIP + GIS is the only supported authentication flow on web.
+- The GCIP API key must not be hardcoded in the built app. It is injected at runtime via an environment variable GCIP_API_KEY that renders into cloudrun-config.js.
+- The web container’s entrypoint renders web/cloudrun-config.template.js to cloudrun-config.js using envsubst with GCIP_API_KEY.
+- The Flutter app must resolve the API key on web from window.cloudRunConfig.gcipApiKey first, then optional meta[name="gcip-api-key"], and only finally fall back to AppConfig.gcipApiKey for non-web/local contexts.
+- Ensure the GCIP API key meets all platform restrictions:
+  - Identity Toolkit API enabled
+  - API restrictions include Identity Toolkit API
+  - Application restrictions allow https://app.cloudtolocalllm.online/*
+- Auth domain and tenant configuration must match GCIP setup; tenant IDs selected explicitly per flow.
+
+## Configuration Contract
+- Web service receives:
+  - GCIP_API_KEY (required)
+  - FIREBASE_PROJECT_ID (optional; aids admin SDK contexts where used)
+- API service receives:
+  - DB_TYPE=postgresql in production
+  - DB_HOST, DB_USER, DB_PASSWORD, DB_NAME
+  - CLOUD_SQL_CONNECTION_NAME when using Cloud SQL Connector (/cloudsql/ mount)
+  - FIREBASE_PROJECT_ID when Firebase Admin SDK is used server-side
+  - LOG_LEVEL, NODE_ENV
+- Streaming service receives minimal env (LOG_LEVEL, NODE_ENV) unless otherwise required.
+
+## Database
+- Production: Cloud SQL for PostgreSQL instance cloudtolocalllm-db.
+- Local development: SQLite is allowed for quick start; do not use SQLite in Cloud Run.
+- The API service must initialize the PostgreSQL migrator (DatabaseMigratorPG) when DB_TYPE=postgresql; otherwise it uses SQLite migrator locally.
+- Database schema migrations run on boot; /api/db/health must report status and schema validation results.
+
+## Networking and Endpoints
+- Primary public web URL: https://app.cloudtolocalllm.online
+- API and streaming subdomains (via Cloud Run custom domains) should be configured and referenced in web/cloudrun-config.js.
+- CORS and allowed origins must include app.cloudtolocalllm.online and Cloud Run service URLs during rollout.
+- Cloud Run services should be public where intended; sensitive admin endpoints must remain protected.
+
+## Security
+- Never hardcode secrets or API keys in source. Replace the legacy hardcoded GCIP key with runtime-configured GCIP_API_KEY.
+- Lock down GCIP API key with API and application restrictions.
+- Cloud Run service accounts:
+  - Use dedicated service accounts (e.g., cloudtolocalllm-runner@<project>.iam.gserviceaccount.com)
+  - Grant minimum roles: Cloud Run Invoker, Cloud SQL Client (API service), Secret Manager Secret Accessor (as needed).
+- Database credentials should be stored in GCP Secret Manager; the GitHub workflow may read and pass them at deploy time.
+- Enforce HTTPS across all public endpoints; avoid mixed content.
+
+## Observability and Health
+- Web: /health static endpoint (Nginx) returns 200 OK.
+- API: /health and /api/db/health. Use structured logging (JSON-friendly) and include correlation IDs when possible.
+- Use Cloud Logging and Cloud Run logs for monitoring deployments and runtime issues. Prefer log levels: error, warn, info, debug (default to info in prod).
+
+## Performance and Scaling
+- Cloud Run parameters should be tuned per service:
+  - Web: memory ~1Gi, cpu=1, concurrency ~80
+  - API: memory ~2Gi, cpu=2, concurrency ~100; timeout suitable for long operations; min instances typically 0 unless warm starts required
+  - Streaming: tuned for long-lived requests; higher timeout
+- Avoid CPU-intensive operations in the web container; push compute to API/streaming services.
+
+## CI/CD and Image Build
+- GitHub Actions workflow .github/workflows/cloudrun-deploy.yml builds images per service, pushes to Artifact Registry, and deploys with gcloud run deploy.
+- Workload Identity Federation (WIF) must be configured with vars.WIF_PROVIDER and vars.WIF_SERVICE_ACCOUNT.
+- GCIP_API_KEY must be provided via GitHub Actions secrets and injected into the web service.
+- The API service deployment must include Cloud SQL attachment (--add-cloudsql-instances) when using DB_HOST=/cloudsql/...
+
+## Conventions
+- Code must not rely on platform-specific plugins that are deprecated for web (e.g., google_sign_in for web). Use GIS directly.
+- Keep region, project ID, and naming consistent across config files and workflows.
+- Put environment-specific overrides into CI/CD (secrets/vars), not into source files.
+
+## Change Management
+- Architectural changes affecting security, auth flows, or data stores must be reviewed.
+- Any change that alters external contracts (URLs, auth method, env var names) must come with migration notes and CI/CD updates.

--- a/.augment/rules/Development_Workflow.md
+++ b/.augment/rules/Development_Workflow.md
@@ -1,0 +1,59 @@
+---
+type: "always_apply"
+description: "CloudToLocalLLM Development Workflow and Practices"
+---
+
+## Principles
+- Prefer modern tooling and configurations (e.g., ESLint 9 flat config) for new code; do not revert to legacy patterns unless strictly necessary.
+- Separate concerns between local builds and cloud deployments: local PowerShell scripts for desktop builds; GitHub Actions for Cloud Run deployments.
+- Preserve existing deployment configurations; add new options as additional choices rather than replacements.
+
+## Branching and PRs
+- Default branch: master (repo default). Working branch: main currently used. Confirm target when opening PRs.
+- Create feature branches: feature/<short-description>, fix/<short-description>, chore/<short-description>.
+- Small, focused PRs. Include a clear description, screenshots/logs for behavioral changes, and a test plan.
+- Require at least one review for changes impacting deployment, auth, or security-sensitive areas.
+
+## Commits
+- Conventional commits encouraged: feat:, fix:, chore:, docs:, refactor:, test:, ci:.
+- Commit early with working increments; avoid large unreviewed dumps.
+
+## Dependency Management
+- Always use package managers, never edit package files directly:
+  - Node/JS: npm ci/install, pnpm add/remove, yarn add/remove
+  - Dart/Flutter: flutter pub add/remove
+  - Python: pip/poetry
+  - Rust/Go/etc: use native tooling
+- Run lockfile updates via the manager; do not hand-edit lockfiles.
+
+## Secrets and Configuration
+- Never hardcode secrets/API keys. Use GitHub Actions Secrets and GCP Secret Manager.
+- Web GCIP API key must be provided via GCIP_API_KEY secret and injected at runtime (via cloudrun-config.js render). Remove or avoid legacy keys in source.
+- Store DB passwords in Secret Manager; fetch in CI and pass as env to Cloud Run.
+
+## Testing
+- Write unit tests for critical services and auth flows.
+- For code changes, ensure CI runs tests and basic builds.
+- When touching authentication, test end-to-end on staging/production Cloud Run: GIS popup → GCIP exchange → secure API calls.
+
+## CI/CD
+- Primary workflow: .github/workflows/cloudrun-deploy.yml
+- Triggers: push to main/master on relevant paths, and manual workflow_dispatch.
+- Auth to GCP via WIF: vars.WIF_PROVIDER and vars.WIF_SERVICE_ACCOUNT must be configured in repo/environment.
+- Required secrets/vars:
+  - secrets.GCIP_API_KEY for web
+  - Secret Manager: db-password (created if missing by workflow)
+  - vars.GCP_PROJECT_ID (default cloudtolocalllm-468303)
+  - vars.GCP_REGION (prefer us-central1 for runtime; ensure consistency)
+- Deployment order: build images → setup database (ensure instance exists, user/password, connection) → deploy services → verify health
+
+## Rollback
+- Keep :latest tags and commit SHA tags. To rollback, redeploy the previous SHA tag via gcloud or re-run the workflow with the desired ref.
+
+## Code Quality
+- Lint and format consistently. Avoid console.log in Node backend; use structured logger. In Flutter, prefer debugPrint with clear prefixes.
+- Avoid deprecated APIs (e.g., google_sign_in plugin on web). Use GIS and GCIP endpoints directly.
+
+## Documentation
+- Update README/DEPLOYMENT docs and rule files when changing architecture, env var names, or deployment steps.
+- Include troubleshooting notes for common issues (e.g., API key restrictions, Cloud SQL connectivity, WIF misconfig).

--- a/.augment/rules/MCP_Tools.md
+++ b/.augment/rules/MCP_Tools.md
@@ -1,0 +1,74 @@
+---
+type: "always_apply"
+description: "MCP/Tools Usage Rules for CloudToLocalLLM"
+---
+
+## Tool Selection Rules
+- Prefer minimal, high-signal tool calls. Each call must have a clear purpose and next action.
+- Always confirm function/class/file existence before editing.
+
+## Codebase Navigation
+- view (file/directory): when you know the path or need to open a file. Use search_query_regex to find symbol usages within a file.
+- grep-search/codebase-retrieval: use when you don’t know the exact file(s). Constrain queries and avoid repeated broad searches.
+- git-commit-retrieval: use to learn prior approaches/rationales from history. Verify against current code afterward.
+
+## Editing Files
+- Use str-replace-editor exclusively for modifications; do not recreate files wholesale.
+- Gather exact old_str ranges before editing. Keep edits under 150 lines per call.
+- Respect existing code style; make the smallest safe change.
+
+## Dependency Management
+- Never hand-edit package manifests or lockfiles. Use proper package managers (npm/yarn/pnpm, flutter pub, etc.).
+
+## Processes and Verification
+- Use launch-process for builds/tests/linters; summarize commands, cwd, exit codes, and key output.
+- Safe-by-default runs are encouraged after changes (tests, lint, small builds). Avoid destructive or costly operations without approval.
+
+## GitHub API Usage
+- Scope all queries to imrightguy/CloudToLocalLLM unless explicitly requested otherwise.
+- Before creating PRs or pushing, ask for permission. When checking CI, use commit status/check-runs endpoints.
+
+## Secrets and Safety
+- Never print secret values. Use environment variables and secret stores (GitHub Secrets, GCP Secret Manager).
+- Do not hardcode secrets in source. Replace legacy keys with runtime injection via CI/CD.
+
+## Communication
+- Start non-trivial work with a short plan and a tasklist.
+- Explain notable actions; keep messages concise and skimmable. Wrap code excerpts in <augment_code_snippet> tags with path and mode.
+
+## Architecture-Specific Notes
+- GCIP API key must be injected at runtime into cloudrun-config.js by docker-entrypoint-web.sh. Ensure workflows pass GCIP_API_KEY to the web service.
+- For the API, pass DB_* and CLOUD_SQL_CONNECTION_NAME via Cloud Run env vars and attach Cloud SQL instances as needed.
+
+## Additional Tools
+
+### Sequential Thinking (sequentialthinking_Sequential_thinking)
+Use for complex, multi-step problem solving when:
+- Planning deployments or migrations with several dependent steps
+- Designing cross-service changes (web, API, streaming, CI/CD)
+- Triaging ambiguous production incidents
+Guidelines:
+- Start with a brief hypothesis and total_thoughts estimate; revise as you learn
+- Keep thoughts focused on the next concrete action; cut branches that don’t add value
+- Conclude with a clear solution hypothesis and verification plan
+
+### Context7 Library Docs (resolve-library-id_Context_7 + get-library-docs_Context_7)
+Use to retrieve authoritative docs/snippets for popular libraries (e.g., Next.js, Firebase, Supabase) when:
+- You need up-to-date API references for implementation decisions
+- You want examples for a specific topic (e.g., hooks, routing, auth)
+Guidelines:
+- Always call resolve-library-id_Context_7 first to get the Context7-compatible ID
+- Then call get-library-docs_Context_7 with a focused topic and reasonable token limit
+- Summarize and cite what’s relevant; don’t paste large dumps
+
+### Playwright Browser Tools (browser_* namespace)
+Use for web automation/testing when you need to:
+- Navigate to deployed environments and validate behavior (e.g., GCIP login flow)
+- Capture console logs, network requests, screenshots, and accessibility snapshots
+- Simulate user actions: click, type, select, submit
+Guidelines:
+- Install the browser via browser_install_Playwright if needed
+- Prefer lightweight checks first (console logs, specific network calls) before full E2E
+- Avoid interacting with production data destructively; read-only validations are preferred
+- Capture key evidence: exit codes, notable console messages, HTTP status codes
+

--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -241,6 +241,12 @@ jobs:
     - name: Deploy Web Service
       if: github.event.inputs.service == 'all' || github.event.inputs.service == '' || github.event.inputs.service == 'web'
       run: |
+        # Resolve GCIP API key: prefer GitHub secret; fallback to GCP Secret Manager
+        GCIP_API_KEY_VAL="${{ secrets.GCIP_API_KEY }}"
+        if [ -z "$GCIP_API_KEY_VAL" ]; then
+          GCIP_API_KEY_VAL="$(gcloud secrets versions access latest --secret=\"gcip-api-key\" 2>/dev/null || echo \"\")"
+        fi
+
         gcloud run deploy cloudtolocalllm-web \
           --image=${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/web:${{ github.sha }} \
           --platform=managed \
@@ -254,7 +260,7 @@ jobs:
           --concurrency=80 \
           --timeout=300 \
           --service-account=cloudtolocalllm-runner@${{ env.PROJECT_ID }}.iam.gserviceaccount.com \
-          --set-env-vars="NODE_ENV=production,LOG_LEVEL=info,FIREBASE_PROJECT_ID=${{ vars.FIREBASE_PROJECT_ID || 'cloudtolocalllm-468303' }},GCIP_API_KEY=${{ secrets.GCIP_API_KEY }}" \
+          --set-env-vars="NODE_ENV=production,LOG_LEVEL=info,FIREBASE_PROJECT_ID=${{ vars.FIREBASE_PROJECT_ID || 'cloudtolocalllm-468303' }},GCIP_API_KEY=$GCIP_API_KEY_VAL" \
           --quiet
 
     - name: Deploy API Service

--- a/config/cloudrun/Dockerfile.web-cloudrun
+++ b/config/cloudrun/Dockerfile.web-cloudrun
@@ -68,9 +68,6 @@ RUN chown -R nginx:nginx /usr/share/nginx/html && \
 # Create health check endpoint
 RUN echo '<!DOCTYPE html><html><body><h1>OK</h1></body></html>' > /usr/share/nginx/html/health
 
-# Switch to non-root user
-USER nginx
-
 # Cloud Run requires listening on PORT environment variable
 # Default to 8080 if not set
 ENV PORT=8080
@@ -82,9 +79,12 @@ EXPOSE $PORT
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl --fail http://localhost:$PORT/health || exit 1
 
-# Copy entrypoint to inject runtime variables
+# Copy entrypoint to inject runtime variables (as root), then set executable
 COPY config/cloudrun/docker-entrypoint-web.sh /usr/local/bin/docker-entrypoint-web.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint-web.sh
+
+# Switch to non-root user
+USER nginx
 
 # Start via entrypoint to inject GCIP_API_KEY and render nginx config
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint-web.sh"]

--- a/config/cloudrun/Dockerfile.web-cloudrun
+++ b/config/cloudrun/Dockerfile.web-cloudrun
@@ -55,6 +55,7 @@ COPY --from=build /app/build/web /usr/share/nginx/html
 
 # Copy Cloud Run configuration files
 COPY web/cloudrun-config.js /usr/share/nginx/html/
+COPY web/cloudrun-config.template.js /usr/share/nginx/html/
 COPY web/subdomain-config.js /usr/share/nginx/html/
 
 # Copy Cloud Run optimized nginx configuration

--- a/lib/services/gcip_auth_service.dart
+++ b/lib/services/gcip_auth_service.dart
@@ -67,7 +67,7 @@ class GCIPAuthService extends ChangeNotifier {
     dynamic cur = window as dynamic;
     for (final key in path) {
       try {
-        cur = (cur as dynamic?)?[key];
+        cur = (cur as dynamic)[key];
       } catch (_) {
         return null;
       }
@@ -493,7 +493,7 @@ class GCIPAuthService extends ChangeNotifier {
 
       debugPrint('🏢 Starting email/password sign-in for tenant: $_currentTenant');
 
-      final url = '$gcipBaseUrl/accounts:signInWithPassword?key=${AppConfig.gcipApiKey}';
+      final url = '$gcipBaseUrl/accounts:signInWithPassword?key=${_getGcipApiKey()}';
 
       final response = await http.post(
         Uri.parse(url),
@@ -538,7 +538,7 @@ class GCIPAuthService extends ChangeNotifier {
 
       debugPrint('🏢 Creating account for tenant: $_currentTenant');
 
-      final url = '$gcipBaseUrl/accounts:signUp?key=${AppConfig.gcipApiKey}';
+      final url = '$gcipBaseUrl/accounts:signUp?key=${_getGcipApiKey()}';
 
       final response = await http.post(
         Uri.parse(url),
@@ -662,7 +662,7 @@ class GCIPAuthService extends ChangeNotifier {
   Future<void> updateDisplayName(String displayName) async {
     try {
       if (_currentUser != null && _currentToken != null) {
-        final url = '$gcipBaseUrl/accounts:update?key=${AppConfig.gcipApiKey}';
+        final url = '$gcipBaseUrl/accounts:update?key=${_getGcipApiKey()}';
 
         final response = await http.post(
           Uri.parse(url),

--- a/web/index.html
+++ b/web/index.html
@@ -45,6 +45,9 @@
   <title>CloudToLocalLLM</title>
   <link rel="manifest" href="manifest.json">
 
+  <!-- Runtime GCIP config injected by Cloud Run entrypoint -->
+  <script src="cloudrun-config.js"></script>
+
   <!-- Google Identity Services (GIS) for Web Sign-In -->
   <meta name="google-signin-client_id" content="923995245673-hn9fcp61bgu7dkrjft0u6vlt3ohjnrth.apps.googleusercontent.com">
   <meta name="gcip-api-key" content="${GCIP_API_KEY}">


### PR DESCRIPTION
This PR implements GCIP runtime injection and deployment hardening:

- Web runtime config injection:
  - Copy cloudrun-config.template.js into the image
  - Load cloudrun-config.js before Flutter bootstrap
  - Dart GCIP auth service now uses runtime key for all REST calls
- Workflow resilience:
  - If secrets.GCIP_API_KEY is absent, fall back to GCP Secret Manager secret `gcip-api-key`
- Docs:
  - Populate .augment/rules/: Architecture, Development_Workflow, MCP_Tools

Why: Fix recurring "API key not valid" by removing build-time/hardcoded key usage and injecting GCIP_API_KEY at runtime. This aligns with our GCIP/GIS architecture and secret management policies.

Test plan:
- Trigger cloudrun-deploy.yml (service=all, environment=production)
- Verify browser console shows correct GCIP key log and no 400s to identitytoolkit.googleapis.com
- Validate GIS→GCIP token exchange; access protected routes
- Check API /api/db/health is healthy (Postgres)

Notes:
- Repo variable GCP_REGION updated to us-central1
- Please review cloudrun-deploy.yml changes (web deploy fallback)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author