### PR TITLE
Fix GKE deployment: resolve digest from build results; correct API/streaming ports

### DIFF
--- a/.github/workflows/gke-deploy.yml
+++ b/.github/workflows/gke-deploy.yml
@@ -69,7 +69,13 @@ jobs:
       - name: 'Resolve image digest'
         id: digest_web
         run: |
-          DIGEST=$(gcloud container images list-tags gcr.io/${{ vars.GCP_PROJECT_ID }}/web --filter="tags:${{ github.sha }}" --format='get(digest)')
+          # Use gcloud builds describe to get the image digest from the build result
+          BUILD_ID="${{ steps.cb_web.outputs.build_id }}"
+          DIGEST=$(gcloud builds describe "$BUILD_ID" --format='value(results.images[0].digest)')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to get digest from build result, falling back to list-tags"
+            DIGEST=$(gcloud container images list-tags gcr.io/${{ vars.GCP_PROJECT_ID }}/web --filter="tags:${{ github.sha }}" --format='get(digest)' --limit=1)
+          fi
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: 'Deploy to GKE'
@@ -137,7 +143,13 @@ jobs:
       - name: 'Resolve image digest'
         id: digest_api
         run: |
-          DIGEST=$(gcloud container images list-tags gcr.io/${{ vars.GCP_PROJECT_ID }}/api-backend --filter="tags:${{ github.sha }}" --format='get(digest)')
+          # Use gcloud builds describe to get the image digest from the build result
+          BUILD_ID="${{ steps.cb_api.outputs.build_id }}"
+          DIGEST=$(gcloud builds describe "$BUILD_ID" --format='value(results.images[0].digest)')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to get digest from build result, falling back to list-tags"
+            DIGEST=$(gcloud container images list-tags gcr.io/${{ vars.GCP_PROJECT_ID }}/api-backend --filter="tags:${{ github.sha }}" --format='get(digest)' --limit=1)
+          fi
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: 'Resolve DB password'
@@ -231,7 +243,13 @@ jobs:
       - name: 'Resolve image digest'
         id: digest_stream
         run: |
-          DIGEST=$(gcloud container images list-tags gcr.io/${{ vars.GCP_PROJECT_ID }}/streaming-proxy --filter="tags:${{ github.sha }}" --format='get(digest)')
+          # Use gcloud builds describe to get the image digest from the build result
+          BUILD_ID="${{ steps.cb_stream.outputs.build_id }}"
+          DIGEST=$(gcloud builds describe "$BUILD_ID" --format='value(results.images[0].digest)')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to get digest from build result, falling back to list-tags"
+            DIGEST=$(gcloud container images list-tags gcr.io/${{ vars.GCP_PROJECT_ID }}/streaming-proxy --filter="tags:${{ github.sha }}" --format='get(digest)' --limit=1)
+          fi
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: 'Deploy to GKE'

--- a/services/api-backend/k8s/deployment.yaml
+++ b/services/api-backend/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       - name: api-backend
         image: gcr.io/cloudtolocalllm-468303/api-backend:latest
         ports:
-        - containerPort: 8080
+        - containerPort: 3000
         env:
         - name: NODE_ENV
           value: "production"
@@ -52,13 +52,13 @@ spec:
         readinessProbe:
           httpGet:
             path: /api/health
-            port: 8080
+            port: 3000
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /api/health
-            port: 8080
+            port: 3000
           initialDelaySeconds: 20
           periodSeconds: 20
         resources:

--- a/services/api-backend/k8s/service.yaml
+++ b/services/api-backend/k8s/service.yaml
@@ -9,4 +9,4 @@ spec:
     app: api-backend
   ports:
   - port: 8080
-    targetPort: 8080
+    targetPort: 3000

--- a/services/streaming-proxy/k8s/deployment.yaml
+++ b/services/streaming-proxy/k8s/deployment.yaml
@@ -22,24 +22,24 @@ spec:
       - name: streaming-proxy
         image: gcr.io/cloudtolocalllm-468303/streaming-proxy:latest
         ports:
-        - containerPort: 8080
+        - containerPort: 3001
         env:
         - name: NODE_ENV
           value: "production"
         - name: LOG_LEVEL
           value: "info"
         - name: HEALTH_PORT
-          value: "8080"
+          value: "3001"
         readinessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: 3001
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: 3001
           initialDelaySeconds: 20
           periodSeconds: 20
         resources:

--- a/services/streaming-proxy/k8s/service.yaml
+++ b/services/streaming-proxy/k8s/service.yaml
@@ -9,4 +9,4 @@ spec:
     app: streaming-proxy
   ports:
   - port: 8080
-    targetPort: 8080
+    targetPort: 3001


### PR DESCRIPTION
Fixes for Deploy to GKE workflow failures:

**Permission Issue Fix:**
- Changed digest resolution to use `gcloud builds describe` instead of `gcloud container images list-tags`
- This avoids the `artifactregistry.repositories.downloadArtifacts` permission requirement
- Falls back to list-tags if build result doesn't contain digest

**Port Configuration Fix:**
- API backend: corrected containerPort from 8080 to 3000 (matches Dockerfile EXPOSE)
- Streaming proxy: corrected containerPort from 8080 to 3001 (matches Dockerfile EXPOSE)
- Updated service targetPort mappings accordingly
- Fixed health check probe ports to match container ports

**Expected Results:**
- Cloud Build should succeed with corrected Dockerfiles
- Digest resolution should work without additional permissions
- Services should be reachable on correct ports
- Health checks should pass

This addresses the failures in run #60 where:
- Web job failed on digest resolution (permission denied)
- API/streaming jobs failed during Cloud Build (likely port mismatches)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author