### PR TITLE
Fix Cloud Build failures: ES modules tracing syntax

### DIFF
--- a/services/api-backend/Dockerfile
+++ b/services/api-backend/Dockerfile
@@ -15,4 +15,5 @@ EXPOSE 3000
 # Run as non-root where possible
 USER node
 
-CMD ["npm", "start"]
+# Use --import for ES modules tracing instead of --require
+CMD ["node", "--import", "./tracing.js", "server.js"]

--- a/services/streaming-proxy/Dockerfile
+++ b/services/streaming-proxy/Dockerfile
@@ -11,4 +11,5 @@ COPY . .
 
 EXPOSE 3001
 USER node
-CMD ["npm", "start"]
+# Use --import for ES modules tracing instead of --require
+CMD ["node", "--import", "./tracing.js", "proxy-server.js"]


### PR DESCRIPTION
**Root Cause:** Cloud Build failures for API backend and streaming proxy due to ES modules/CommonJS mismatch in tracing configuration.

**Problem:**
- Both services use `"type": "module"` (ES modules)
- `tracing.js` files use `import` statements (ES modules)
- Start scripts used `--require ./tracing.js` (CommonJS syntax)
- Node.js failed on startup: cannot require ES module files

**Solution:**
- API backend: Changed CMD to `node --import ./tracing.js server.js`
- Streaming proxy: Changed CMD to `node --import ./tracing.js proxy-server.js`
- `--import` is the correct syntax for ES modules with tracing

**Expected Results:**
- Cloud Build should succeed for all three services
- API and streaming containers should start properly
- Tracing should work correctly with ES modules

**Verification:**
- Web job already succeeded in previous run
- This fix targets the specific failure in API/streaming jobs
- Addresses Issue #97 deployment pipeline requirements

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author