### PR TITLE
fix(gke): restore web availability via CI (namespace, ManagedCertificate, web secrets/config, API PORT=3000)

### DIFF
--- a/.github/workflows/gke-deploy.yml
+++ b/.github/workflows/gke-deploy.yml
@@ -80,9 +80,20 @@ jobs:
 
       - name: 'Deploy to GKE'
         run: |
-          kubectl apply -f web/k8s/deployment.yaml
-          kubectl apply -f web/k8s/service.yaml
-          kubectl apply -f web/k8s/ingress.yaml
+          # Ensure namespace and managed certificate
+          kubectl apply -f config/kubernetes/base/namespace.yaml
+          kubectl -n cloudtolocalllm apply -f gke/managed-certificate.yaml
+
+          # Ensure Web ConfigMap and Secret exist
+          kubectl -n cloudtolocalllm apply -f web/k8s/configmap.yaml
+          kubectl -n cloudtolocalllm create secret generic web-secrets \
+            --from-literal=gcip-api-key='${{ secrets.GCIP_API_KEY }}' \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          # Apply web resources and update image to built digest
+          kubectl -n cloudtolocalllm apply -f web/k8s/deployment.yaml
+          kubectl -n cloudtolocalllm apply -f web/k8s/service.yaml
+          kubectl -n cloudtolocalllm apply -f web/k8s/ingress.yaml
           kubectl -n cloudtolocalllm set image deployment/web web=gcr.io/${{ vars.GCP_PROJECT_ID }}/web@${{ steps.digest_web.outputs.digest }}
 
   deploy-api:
@@ -254,9 +265,13 @@ jobs:
 
       - name: 'Deploy to GKE'
         run: |
-          kubectl apply -f services/streaming-proxy/k8s/deployment.yaml
-          kubectl apply -f services/streaming-proxy/k8s/service.yaml
-          kubectl apply -f services/streaming-proxy/k8s/ingress.yaml
+          # Ensure namespace exists
+          kubectl apply -f config/kubernetes/base/namespace.yaml
+
+          # Apply streaming resources and update image
+          kubectl -n cloudtolocalllm apply -f services/streaming-proxy/k8s/deployment.yaml
+          kubectl -n cloudtolocalllm apply -f services/streaming-proxy/k8s/service.yaml
+          kubectl -n cloudtolocalllm apply -f services/streaming-proxy/k8s/ingress.yaml
           kubectl -n cloudtolocalllm set image deployment/streaming-proxy streaming-proxy=gcr.io/${{ vars.GCP_PROJECT_ID }}/streaming-proxy@${{ steps.digest_stream.outputs.digest }}
 
   validate-deployment:

--- a/services/api-backend/k8s/deployment.yaml
+++ b/services/api-backend/k8s/deployment.yaml
@@ -29,6 +29,8 @@ spec:
           value: "production"
         - name: LOG_LEVEL
           value: "info"
+        - name: PORT
+          value: "3000"
         - name: DB_TYPE
           value: "postgresql"
         - name: DB_HOST


### PR DESCRIPTION
Context: Restore basic web application functionality on GKE using existing CI/CD.

Changes:
- API backend Deployment: set `PORT=3000` to match Service targetPort and health probes
- GKE workflow (deploy-web job): ensure namespace and ManagedCertificate are applied; ensure web ConfigMap and `web-secrets` (GCIP_API_KEY) are created before Deployment
- GKE workflow (deploy-streaming job): ensure namespace is applied before resources (idempotent)

Why:
- Web pods require `web-config` (API_BASE_URL, STREAMING_BASE_URL) and `web-secrets` (GCIP_API_KEY) for the init container to render config; missing these causes startup failures.
- API Deployment previously relied on default PORT, causing port mismatch (Service targetPort=3000; probes on 3000). Explicit env fixes health checks.
- ManagedCertificate is referenced by Ingress annotations and must exist for HTTPS to provision properly.

Validation plan (CI):
- This PR relies on `.github/workflows/gke-deploy.yml` to:
  - Build and push images via Cloud Build
  - Apply namespace, cert, ConfigMap, Secret, Deployments, Services, Ingresses
  - Set images by digest
  - Run validation and k6 smoke stages

Rollout:
- Once merged, the workflow will deploy to cluster `cloudtolocalllm-us-central1`, namespace `cloudtolocalllm`.

Please review and approve to trigger automated deployment. If urgent deploy is needed pre-merge, we can dispatch the workflow on this branch as a one-time exception.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author